### PR TITLE
feat: update references from easy-http/layer-contracts to easy-http/contracts 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4|^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.0|^7.0",
-        "easy-http/layer-contracts": "^1.0"
+        "easy-http/contracts": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.2",

--- a/src/GuzzleAdapter.php
+++ b/src/GuzzleAdapter.php
@@ -2,11 +2,11 @@
 
 namespace EasyHttp\GuzzleAdapter;
 
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
-use EasyHttp\LayerContracts\Contracts\HttpClientResponse;
-use EasyHttp\LayerContracts\Exceptions\HttpClientException;
-use EasyHttp\LayerContracts\Exceptions\HttpConnectionException;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\Contracts\HttpClientResponse;
+use EasyHttp\Contracts\Exceptions\HttpClientException;
+use EasyHttp\Contracts\Exceptions\HttpConnectionException;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;

--- a/src/GuzzleClient.php
+++ b/src/GuzzleClient.php
@@ -3,9 +3,9 @@
 namespace EasyHttp\GuzzleAdapter;
 
 use EasyHttp\GuzzleAdapter\Factories\ClientFactory;
-use EasyHttp\LayerContracts\AbstractClient;
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\AbstractClient;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
 
 class GuzzleClient extends AbstractClient
 {

--- a/src/GuzzleRequest.php
+++ b/src/GuzzleRequest.php
@@ -2,7 +2,7 @@
 
 namespace EasyHttp\GuzzleAdapter;
 
-use EasyHttp\LayerContracts\Common\ClientRequest;
+use EasyHttp\Contracts\Common\ClientRequest;
 
 class GuzzleRequest extends ClientRequest
 {

--- a/src/GuzzleResponse.php
+++ b/src/GuzzleResponse.php
@@ -3,8 +3,8 @@
 namespace EasyHttp\GuzzleAdapter;
 
 use EasyHttp\GuzzleAdapter\Concerns\NeedsParseHeaders;
-use EasyHttp\LayerContracts\Contracts\HttpClientResponse;
-use EasyHttp\LayerContracts\Exceptions\ImpossibleToParseJsonException;
+use EasyHttp\Contracts\Contracts\HttpClientResponse;
+use EasyHttp\Contracts\Exceptions\ImpossibleToParseJsonException;
 use Psr\Http\Message\ResponseInterface;
 
 class GuzzleResponse implements HttpClientResponse

--- a/tests/GuzzleAdapterCertificateAuthenticationTest.php
+++ b/tests/GuzzleAdapterCertificateAuthenticationTest.php
@@ -4,8 +4,8 @@ namespace Tests;
 
 use EasyHttp\GuzzleAdapter\GuzzleAdapter;
 use EasyHttp\GuzzleAdapter\GuzzleRequest;
-use EasyHttp\LayerContracts\Common\SecurityContext;
-use EasyHttp\LayerContracts\Exceptions\HttpClientException;
+use EasyHttp\Contracts\Common\SecurityContext;
+use EasyHttp\Contracts\Exceptions\HttpClientException;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use Tests\Mocks\CertificateApi;

--- a/tests/GuzzleAdapterSSLVerificationTest.php
+++ b/tests/GuzzleAdapterSSLVerificationTest.php
@@ -4,8 +4,8 @@ namespace Tests;
 
 use EasyHttp\GuzzleAdapter\GuzzleAdapter;
 use EasyHttp\GuzzleAdapter\GuzzleRequest;
-use EasyHttp\LayerContracts\Common\SecurityContext;
-use EasyHttp\LayerContracts\Exceptions\HttpClientException;
+use EasyHttp\Contracts\Common\SecurityContext;
+use EasyHttp\Contracts\Exceptions\HttpClientException;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use Tests\Mocks\CertificateApi;

--- a/tests/GuzzleAdapterTest.php
+++ b/tests/GuzzleAdapterTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use EasyHttp\LayerContracts\Exceptions\HttpClientException;
-use EasyHttp\LayerContracts\Exceptions\HttpConnectionException;
+use EasyHttp\Contracts\Exceptions\HttpClientException;
+use EasyHttp\Contracts\Exceptions\HttpConnectionException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use EasyHttp\LayerContracts\Exceptions\HttpClientException;
-use EasyHttp\LayerContracts\Exceptions\ImpossibleToParseJsonException;
+use EasyHttp\Contracts\Exceptions\HttpClientException;
+use EasyHttp\Contracts\Exceptions\ImpossibleToParseJsonException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use PHPUnit\Framework\TestCase;

--- a/tests/GuzzleRequestTest.php
+++ b/tests/GuzzleRequestTest.php
@@ -4,8 +4,8 @@ namespace Tests;
 
 use EasyHttp\GuzzleAdapter\GuzzleAdapter;
 use EasyHttp\GuzzleAdapter\GuzzleRequest;
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 

--- a/tests/GuzzleResponseTest.php
+++ b/tests/GuzzleResponseTest.php
@@ -4,7 +4,7 @@ namespace Tests;
 
 use EasyHttp\GuzzleAdapter\GuzzleAdapter;
 use EasyHttp\GuzzleAdapter\GuzzleRequest;
-use EasyHttp\LayerContracts\Exceptions\ImpossibleToParseJsonException;
+use EasyHttp\Contracts\Exceptions\ImpossibleToParseJsonException;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use PHPUnit\Framework\TestCase;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
 use PHPUnit\Framework\TestCase;
 use Tests\Concerns\HasMock;
 use Tests\Mocks\HttpInfo;


### PR DESCRIPTION
This pull request updates the codebase to use the new `easy-http/contracts` package (version 2.0) instead of the deprecated `easy-http/layer-contracts` package (version 1.0). The changes involve updating dependencies and modifying import statements across multiple files.